### PR TITLE
Disambiguate `never` usage to make code elm-0.19.1 compatible

### DIFF
--- a/src/TokenProcessors.elm
+++ b/src/TokenProcessors.elm
@@ -33,7 +33,6 @@ import Regex
         ( Regex
           -- , HowMany(..)
         , fromString
-        , never
         , replace
         , split
         )
@@ -42,7 +41,7 @@ import String exposing (toLower, trim)
 
 forceRegex : String -> Regex
 forceRegex =
-    Maybe.withDefault never << fromString
+    Maybe.withDefault Regex.never << fromString
 
 
 defaultSeparator : Regex


### PR DESCRIPTION
In the upcoming elm 0.19.1 release, a bug in the elm compiler was fixed (https://github.com/elm/compiler/issues/1945) which makes your code incompatible with the 0.19.1 release.

This PR fixes the problem by disambiguating usage of the name `never` which may come from two packages in the affected module: `Regex.never` and `Basics.never` (not really imported but visible everywhere).