### PR TITLE
Problems with `ElmTextSearch.remove` and later calls to `ElmTextSearch.search`

### DIFF
--- a/tests/IndexTests.elm
+++ b/tests/IndexTests.elm
@@ -10,8 +10,8 @@ module IndexTests exposing
     , idfCacheIsClearedAfterSuccessfulRemove
     , removeDocRefNotIndexReturnsError
     , removeDocWithEmptyIdFieldReturnsError
-    , removeOnlyDocIndexReturnsIsEmpty
     , removeDoesNotBreakSearchResults
+    , removeOnlyDocIndexReturnsIsEmpty
     , searchCasesTest
     , searchEmptyIndexReturnsError
     , searchListFieldsSingleLetterWithLetterInBody
@@ -323,6 +323,7 @@ removeDocWithEmptyIdFieldReturnsError =
                 |> Index.remove doc5_idEmpty
                 |> Expect.equal (Err "Error document has an empty unique id (ref).")
 
+
 removeDoesNotBreakSearchResults : Test
 removeDoesNotBreakSearchResults =
     test "Remove does not break searching" <|
@@ -334,7 +335,8 @@ removeDoesNotBreakSearchResults =
                 |> TestUtils.getResultIgnoreError
                 |> Tuple.second
                 |> List.map Tuple.first
-                |> Expect.equal [doc1_.cid]
+                |> Expect.equal [ doc1_.cid ]
+
 
 {-| Test to verify removing only document reports
 -}

--- a/tests/IndexTests.elm
+++ b/tests/IndexTests.elm
@@ -11,6 +11,7 @@ module IndexTests exposing
     , removeDocRefNotIndexReturnsError
     , removeDocWithEmptyIdFieldReturnsError
     , removeOnlyDocIndexReturnsIsEmpty
+    , removeDoesNotBreakSearchResults
     , searchCasesTest
     , searchEmptyIndexReturnsError
     , searchListFieldsSingleLetterWithLetterInBody
@@ -322,6 +323,18 @@ removeDocWithEmptyIdFieldReturnsError =
                 |> Index.remove doc5_idEmpty
                 |> Expect.equal (Err "Error document has an empty unique id (ref).")
 
+removeDoesNotBreakSearchResults : Test
+removeDoesNotBreakSearchResults =
+    test "Remove does not break searching" <|
+        \() ->
+            getIndexDoc1Doc2 ()
+                |> Index.remove doc2_
+                |> TestUtils.getResultIgnoreError
+                |> Index.search "Sally"
+                |> TestUtils.getResultIgnoreError
+                |> Tuple.second
+                |> List.map Tuple.first
+                |> Expect.equal [doc1_.cid]
 
 {-| Test to verify removing only document reports
 -}


### PR DESCRIPTION
Hey there! For starters, thanks for making this awesome library!

I was having some problems today with `ElmTextSearch.remove`. After calling it to remove a document from an index, I noticed that later search results seemed to come up empty. Perhaps I have misinterpreted what `remove` is supposed to do. Either way, I think I was able to reproduce it what I was seeing with a failing test.

For example, try removing the call to `remove` in the test, and you'll see that the test will start passing:

```elm
removeDoesNotBreakSearchResults : Test
removeDoesNotBreakSearchResults =
    test "Remove does not break searching" <|
        \() ->
            getIndexDoc1Doc2 ()
                -- Commenting these lines causes the test to pass
                -- |> Index.remove doc2_
                -- |> TestUtils.getResultIgnoreError
                |> Index.search "Sally"
                |> TestUtils.getResultIgnoreError
                |> Tuple.second
                |> List.map Tuple.first
                |> Expect.equal [doc1_.cid]
```

I'm not familiar with the internals of the library, so I didn't attempt a fix. However, even before that, does this seem like an actual bug?